### PR TITLE
feat: auto-promote deploy to flyio

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,45 @@
+# This file excludes paths from the Docker build context.
+#
+# By default, Docker's build context includes all files (and folders) in the
+# current directory. Even if a file isn't copied into the container it is still sent to
+# the Docker daemon.
+#
+# There are multiple reasons to exclude files from the build context:
+#
+# 1. Prevent nested folders from being copied into the container (ex: exclude
+#    /assets/node_modules when copying /assets)
+# 2. Reduce the size of the build context and improve build time (ex. /build, /deps, /doc)
+# 3. Avoid sending files containing sensitive information
+#
+# More information on using .dockerignore is available here:
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
+.dockerignore
+
+# Ignore git, but keep git HEAD and refs to access current commit hash if needed:
+#
+# $ cat .git/HEAD | awk '{print ".git/"$2}' | xargs cat
+# d0b8727759e1e0e7aa3d41707d12376e373d5ecc
+.git
+!.git/HEAD
+!.git/refs
+
+# Common development/test artifacts
+/cover/
+/doc/
+/test/
+/tmp/
+.elixir_ls
+
+# Mix artifacts
+/_build/
+/deps/
+*.ez
+
+# Generated on crash by the VM
+erl_crash.dump
+
+# Static artifacts - These should be fetched and built inside the Docker image
+/assets/node_modules/
+/priv/static/assets/
+/priv/static/cache_manifest.json

--- a/.semaphore/production-deploy.yml
+++ b/.semaphore/production-deploy.yml
@@ -1,0 +1,22 @@
+version: v1.0
+
+name: Auto-promote fly deploy
+
+agent:
+  machine:
+    type: e2-standard-2
+    os_image: ubuntu2204
+
+blocks:
+  - name: "\U0001F680 Deploy to Fly.io"
+    task:
+      secrets:
+        - name: flyio
+      prologue:
+        commands:
+          - checkout
+      jobs:
+        - name: build and deploy
+          commands:
+            - curl -L https://fly.io/install.sh | sh
+            - flyctl deploy --remote-only

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -28,7 +28,7 @@ blocks:
         - name: mix deps.get and cache
           commands:
             - sem-version elixir 1.14
-            - if [ $SEMAPHORE_WORKFLOW_RERUN ]; then mix deps.clean --all && mix clean; else cache restore; fi
+            - cache restore
             - mix deps.get
             - mix compile --warnings-as-errors
             - cache store

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -28,6 +28,7 @@ blocks:
         - name: mix deps.get and cache
           commands:
             - sem-version elixir 1.14
+            - cache clear
             - cache restore
             - mix deps.get
             - mix compile --warnings-as-errors

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -28,12 +28,7 @@ blocks:
         - name: mix deps.get and cache
           commands:
             - sem-version elixir 1.14
-            - if [ $SEMAPHORE_WORKFLOW_RERUN ]; then
-                mix deps.clean --all;
-                mix clean
-              else
-                cache restore
-              fi
+            - if [ $SEMAPHORE_WORKFLOW_RERUN ]; then mix deps.clean --all && mix clean; else cache restore; fi
             - mix deps.get
             - mix compile --warnings-as-errors
             - cache store

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -28,7 +28,7 @@ blocks:
         - name: mix deps.get and cache
           commands:
             - sem-version elixir 1.14
-            - cache clear
+            - mix local.rebar --force
             - cache restore
             - mix deps.get
             - mix compile --warnings-as-errors

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -28,7 +28,6 @@ blocks:
         - name: mix deps.get and cache
           commands:
             - sem-version elixir 1.14
-            - mix local.rebar --force
             - cache restore
             - mix deps.get
             - mix compile --warnings-as-errors
@@ -96,7 +95,7 @@ blocks:
         commands:
           - checkout
       jobs:
-        - name: phoenix (elixir)
+        - name: ex_unit
           commands:
             - sem-version elixir 1.14
             - cache restore

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -28,11 +28,15 @@ blocks:
         - name: mix deps.get and cache
           commands:
             - sem-version elixir 1.14
-            - cache restore
+            - if [ $SEMAPHORE_WORKFLOW_RERUN ]; then
+                mix deps.clean --all;
+                mix clean
+              else
+                cache restore
+              fi
             - mix deps.get
-            - mix compile
+            - mix compile --warnings-as-errors
             - cache store
-
         - name: yarn install and cache
           commands:
             - sem-version node 20
@@ -60,6 +64,18 @@ blocks:
             - cache restore
             - mix format --check-formatted
             - mix credo
+
+        - name: hex.pm audit (elixir)
+          commands:
+            - sem-version elixir 1.14
+            - cache restore
+            - mix hex.audit
+
+        - name: no unused deps (elixir)
+          commands:
+            - sem-version elixir 1.14
+            - cache restore
+            - mix deps.unlock --check-unused
 
         - name: format & lint (javascript)
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,7 +27,7 @@ blocks:
       jobs:
         - name: mix deps.get and cache
           commands:
-            - sem-version elixir 1.15
+            - sem-version elixir 1.14
             - cache restore
             - mix deps.get
             - mix compile
@@ -56,7 +56,7 @@ blocks:
       jobs:
         - name: format & lint (elixir)
           commands:
-            - sem-version elixir 1.15
+            - sem-version elixir 1.14
             - cache restore
             - mix format --check-formatted
             - mix credo
@@ -86,7 +86,7 @@ blocks:
       jobs:
         - name: phoenix (elixir)
           commands:
-            - sem-version elixir 1.15
+            - sem-version elixir 1.14
             - cache restore
             - curl -Os https://uploader.codecov.io/latest/linux/codecov
             - chmod +x codecov
@@ -109,3 +109,9 @@ blocks:
         - name: playwright
           commands:
             - echo "coming soon..."
+
+promotions:
+  - name: Production deploy
+    pipeline_file: production-deploy.yml
+    auto_promote:
+      when: "result = 'passed' and branch = 'main'"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,108 @@
+# Find eligible builder and runner images on Docker Hub. We use Ubuntu/Debian
+# instead of Alpine to avoid DNS resolution issues in production.
+#
+# https://hub.docker.com/r/hexpm/elixir/tags?page=1&name=ubuntu
+# https://hub.docker.com/_/ubuntu?tab=tags
+#
+# This file is based on these images:
+#
+#   - https://hub.docker.com/r/hexpm/elixir/tags - for the build image
+#   - https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye-20230227-slim - for the release image
+#   - https://pkgs.org/ - resource for finding needed packages
+#   - Ex: hexpm/elixir:1.14.4-erlang-25.3.2-debian-bullseye-20230227-slim
+#
+ARG ELIXIR_VERSION=1.14.4
+ARG OTP_VERSION=25.3.2
+ARG DEBIAN_VERSION=bullseye-20230227-slim
+
+ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
+ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
+
+FROM ${BUILDER_IMAGE} as builder
+
+# add node and yarn apt sources
+# https://github.com/nodesource/distributions/blob/master/README.md
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+
+# install build dependencies
+RUN apt-get update -y && \
+    apt-get install -y build-essential curl git nodejs yarn && \
+    apt-get clean && \
+    rm -f /var/lib/apt/lists/*_*
+
+# prepare build dir
+WORKDIR /app
+
+# install hex + rebar
+RUN mix local.hex --force && \
+    mix local.rebar --force
+
+# set build ENV
+ENV MIX_ENV="prod"
+ENV NODE_ENV="production"
+
+# install mix dependencies
+COPY mix.exs mix.lock ./
+RUN mix deps.get --only $MIX_ENV
+RUN mkdir config
+
+# copy compile-time config files before we compile dependencies
+# to ensure any relevant config change will trigger the dependencies
+# to be re-compiled.
+COPY config/config.exs config/${MIX_ENV}.exs config/
+RUN mix deps.compile
+
+COPY priv priv
+
+COPY lib lib
+
+COPY assets assets
+
+RUN cd assets && \
+    yarn install --production --frozen-lockfile
+
+# compile assets
+RUN mix assets.deploy
+
+# Compile the release
+RUN mix compile
+
+# Changes to config/runtime.exs don't require recompiling the code
+COPY config/runtime.exs config/
+
+COPY rel rel
+RUN mix release
+
+# start a new build stage so that the final image will only contain
+# the compiled release and other runtime necessities
+FROM ${RUNNER_IMAGE}
+
+RUN apt-get update -y && \
+    apt-get install -y libstdc++6 openssl libncurses5 locales && \
+    apt-get clean && \
+    rm -f /var/lib/apt/lists/*_*
+
+# Set the locale
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+WORKDIR "/app"
+RUN chown nobody /app
+
+# set runner ENV
+ENV MIX_ENV="prod"
+
+# Only copy the final release from the build stage
+COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/oberan ./
+
+USER nobody
+
+CMD ["/app/bin/server"]

--- a/assets/package.json
+++ b/assets/package.json
@@ -5,6 +5,10 @@
   "main": "js/app.js",
   "author": "oberandev",
   "license": "MIT",
+  "engines": {
+    "node": ">=18",
+    "yarn": ">=1.22 <2"
+  },
   "scripts": {
     "format": "yarn prettier --write '**/*.{css,js,ts}'",
     "format:check": "yarn prettier --check '**/*.{css,js,ts}'",

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -160,15 +160,15 @@
   integrity sha512-7aqorHYgdNO4DM36stTiGO3DvKoex9TQRwsJU6vMaFGyqpBA1MNZkz+PG3gaNUPpTAOYhT1WR7M1JyA3fbS9Cw==
 
 "@typescript-eslint/eslint-plugin@^6.7.0":
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.0.tgz#ed2a38867190f8a688af85ad7c8a74670b8b3675"
-  integrity sha512-gUqtknHm0TDs1LhY12K2NA3Rmlmp88jK9Tx8vGZMfHeNMLE3GH2e9TRub+y+SOjuYgtOmok+wt1AyDPZqxbNag==
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.2.tgz#f18cc75c9cceac8080a9dc2e7d166008c5207b9f"
+  integrity sha512-ooaHxlmSgZTM6CHYAFRlifqh1OAr3PAQEwi7lhYhaegbnXrnh7CDcHmc3+ihhbQC7H0i4JF0psI5ehzkF6Yl6Q==
   dependencies:
     "@eslint-community/regexpp" "^4.5.1"
-    "@typescript-eslint/scope-manager" "6.7.0"
-    "@typescript-eslint/type-utils" "6.7.0"
-    "@typescript-eslint/utils" "6.7.0"
-    "@typescript-eslint/visitor-keys" "6.7.0"
+    "@typescript-eslint/scope-manager" "6.7.2"
+    "@typescript-eslint/type-utils" "6.7.2"
+    "@typescript-eslint/utils" "6.7.2"
+    "@typescript-eslint/visitor-keys" "6.7.2"
     debug "^4.3.4"
     graphemer "^1.4.0"
     ignore "^5.2.4"
@@ -177,71 +177,71 @@
     ts-api-utils "^1.0.1"
 
 "@typescript-eslint/parser@^6.7.0":
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-6.7.0.tgz#332fe9c7ecf6783d3250b4c8a960bd4af0995807"
-  integrity sha512-jZKYwqNpNm5kzPVP5z1JXAuxjtl2uG+5NpaMocFPTNC2EdYIgbXIPImObOkhbONxtFTTdoZstLZefbaK+wXZng==
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-6.7.2.tgz#e0ae93771441b9518e67d0660c79e3a105497af4"
+  integrity sha512-KA3E4ox0ws+SPyxQf9iSI25R6b4Ne78ORhNHeVKrPQnoYsb9UhieoiRoJgrzgEeKGOXhcY1i8YtOeCHHTDa6Fw==
   dependencies:
-    "@typescript-eslint/scope-manager" "6.7.0"
-    "@typescript-eslint/types" "6.7.0"
-    "@typescript-eslint/typescript-estree" "6.7.0"
-    "@typescript-eslint/visitor-keys" "6.7.0"
+    "@typescript-eslint/scope-manager" "6.7.2"
+    "@typescript-eslint/types" "6.7.2"
+    "@typescript-eslint/typescript-estree" "6.7.2"
+    "@typescript-eslint/visitor-keys" "6.7.2"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@6.7.0":
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-6.7.0.tgz#6b3c22187976e2bf5ed0dc0d9095f1f2cbd1d106"
-  integrity sha512-lAT1Uau20lQyjoLUQ5FUMSX/dS07qux9rYd5FGzKz/Kf8W8ccuvMyldb8hadHdK/qOI7aikvQWqulnEq2nCEYA==
+"@typescript-eslint/scope-manager@6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-6.7.2.tgz#cf59a2095d2f894770c94be489648ad1c78dc689"
+  integrity sha512-bgi6plgyZjEqapr7u2mhxGR6E8WCzKNUFWNh6fkpVe9+yzRZeYtDTbsIBzKbcxI+r1qVWt6VIoMSNZ4r2A+6Yw==
   dependencies:
-    "@typescript-eslint/types" "6.7.0"
-    "@typescript-eslint/visitor-keys" "6.7.0"
+    "@typescript-eslint/types" "6.7.2"
+    "@typescript-eslint/visitor-keys" "6.7.2"
 
-"@typescript-eslint/type-utils@6.7.0":
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-6.7.0.tgz#21a013d4c7f96255f5e64ac59fb41301d1e052ba"
-  integrity sha512-f/QabJgDAlpSz3qduCyQT0Fw7hHpmhOzY/Rv6zO3yO+HVIdPfIWhrQoAyG+uZVtWAIS85zAyzgAFfyEr+MgBpg==
+"@typescript-eslint/type-utils@6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-6.7.2.tgz#ed921c9db87d72fa2939fee242d700561454f367"
+  integrity sha512-36F4fOYIROYRl0qj95dYKx6kybddLtsbmPIYNK0OBeXv2j9L5nZ17j9jmfy+bIDHKQgn2EZX+cofsqi8NPATBQ==
   dependencies:
-    "@typescript-eslint/typescript-estree" "6.7.0"
-    "@typescript-eslint/utils" "6.7.0"
+    "@typescript-eslint/typescript-estree" "6.7.2"
+    "@typescript-eslint/utils" "6.7.2"
     debug "^4.3.4"
     ts-api-utils "^1.0.1"
 
-"@typescript-eslint/types@6.7.0":
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.7.0.tgz#8de8ba9cafadc38e89003fe303e219c9250089ae"
-  integrity sha512-ihPfvOp7pOcN/ysoj0RpBPOx3HQTJTrIN8UZK+WFd3/iDeFHHqeyYxa4hQk4rMhsz9H9mXpR61IzwlBVGXtl9Q==
+"@typescript-eslint/types@6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.7.2.tgz#75a615a6dbeca09cafd102fe7f465da1d8a3c066"
+  integrity sha512-flJYwMYgnUNDAN9/GAI3l8+wTmvTYdv64fcH8aoJK76Y+1FCZ08RtI5zDerM/FYT5DMkAc+19E4aLmd5KqdFyg==
 
-"@typescript-eslint/typescript-estree@6.7.0":
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.0.tgz#20ce2801733bd46f02cc0f141f5b63fbbf2afb63"
-  integrity sha512-dPvkXj3n6e9yd/0LfojNU8VMUGHWiLuBZvbM6V6QYD+2qxqInE7J+J/ieY2iGwR9ivf/R/haWGkIj04WVUeiSQ==
+"@typescript-eslint/typescript-estree@6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.2.tgz#ce5883c23b581a5caf878af641e49dd0349238c7"
+  integrity sha512-kiJKVMLkoSciGyFU0TOY0fRxnp9qq1AzVOHNeN1+B9erKFCJ4Z8WdjAkKQPP+b1pWStGFqezMLltxO+308dJTQ==
   dependencies:
-    "@typescript-eslint/types" "6.7.0"
-    "@typescript-eslint/visitor-keys" "6.7.0"
+    "@typescript-eslint/types" "6.7.2"
+    "@typescript-eslint/visitor-keys" "6.7.2"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
     semver "^7.5.4"
     ts-api-utils "^1.0.1"
 
-"@typescript-eslint/utils@6.7.0":
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-6.7.0.tgz#61b6f1f1b82ad529abfcee074d21764e880886fb"
-  integrity sha512-MfCq3cM0vh2slSikQYqK2Gq52gvOhe57vD2RM3V4gQRZYX4rDPnKLu5p6cm89+LJiGlwEXU8hkYxhqqEC/V3qA==
+"@typescript-eslint/utils@6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-6.7.2.tgz#b9ef0da6f04932167a9222cb4ac59cb187165ebf"
+  integrity sha512-ZCcBJug/TS6fXRTsoTkgnsvyWSiXwMNiPzBUani7hDidBdj1779qwM1FIAmpH4lvlOZNF3EScsxxuGifjpLSWQ==
   dependencies:
     "@eslint-community/eslint-utils" "^4.4.0"
     "@types/json-schema" "^7.0.12"
     "@types/semver" "^7.5.0"
-    "@typescript-eslint/scope-manager" "6.7.0"
-    "@typescript-eslint/types" "6.7.0"
-    "@typescript-eslint/typescript-estree" "6.7.0"
+    "@typescript-eslint/scope-manager" "6.7.2"
+    "@typescript-eslint/types" "6.7.2"
+    "@typescript-eslint/typescript-estree" "6.7.2"
     semver "^7.5.4"
 
-"@typescript-eslint/visitor-keys@6.7.0":
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.0.tgz#34140ac76dfb6316d17012e4469acf3366ad3f44"
-  integrity sha512-/C1RVgKFDmGMcVGeD8HjKv2bd72oI1KxQDeY8uc66gw9R0OK0eMq48cA+jv9/2Ag6cdrsUGySm1yzYmfz0hxwQ==
+"@typescript-eslint/visitor-keys@6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.2.tgz#4cb2bd786f1f459731b0ad1584c9f73e1c7a4d5c"
+  integrity sha512-uVw9VIMFBUTz8rIeaUT3fFe8xIUx8r4ywAdlQv1ifH+6acn/XF8Y6rwJ7XNmkNMDrTW+7+vxFFPIF40nJCVsMQ==
   dependencies:
-    "@typescript-eslint/types" "6.7.0"
+    "@typescript-eslint/types" "6.7.2"
     eslint-visitor-keys "^3.4.1"
 
 acorn-jsx@^5.3.2:

--- a/config/config.exs
+++ b/config/config.exs
@@ -28,17 +28,17 @@ config :oberan, Oberan.Mailer, adapter: Swoosh.Adapters.Local
 
 # Configure esbuild (the version is required)
 config :esbuild,
-  version: "0.17.11",
+  version: "0.19.3",
   default: [
     args:
-      ~w(js/app.js --bundle --target=es2017 --outdir=../priv/static/assets --external:/fonts/* --external:/images/*),
+      ~w(js/app.js --bundle --target=esnext --outdir=../priv/static/assets --external:/fonts/* --external:/images/*),
     cd: Path.expand("../assets", __DIR__),
     env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
   ]
 
 # Configure tailwind (the version is required)
 config :tailwind,
-  version: "3.3.2",
+  version: "3.3.3",
   default: [
     args: ~w(
       --config=tailwind.config.js

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,27 @@
+# fly.toml app configuration file generated for oberandev on 2023-09-21T19:58:26-06:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "oberandev"
+primary_region = "dfw"
+kill_signal = "SIGTERM"
+swap_size_mb = 512
+
+[build]
+
+[env]
+  PHX_HOST = "oberandev.fly.dev"
+  PORT = "8080"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+  [http_service.concurrency]
+    type = "connections"
+    hard_limit = 1000
+    soft_limit = 1000

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# configure node for distributed erlang with IPV6 support
+export ERL_AFLAGS="-proto_dist inet6_tcp"
+export ECTO_IPV6="true"
+export DNS_CLUSTER_QUERY="${FLY_APP_NAME}.internal"
+export RELEASE_DISTRIBUTION="name"
+export RELEASE_NODE="${FLY_APP_NAME}-${FLY_IMAGE_REF##*-}@${FLY_PRIVATE_IP}"

--- a/rel/overlays/bin/server
+++ b/rel/overlays/bin/server
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd -P -- "$(dirname -- "$0")"
+PHX_SERVER=true exec ./oberan start

--- a/rel/overlays/bin/server.bat
+++ b/rel/overlays/bin/server.bat
@@ -1,0 +1,2 @@
+set PHX_SERVER=true
+call "%~dp0\oberan" start

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,7 @@ let
   inherit (pkgs.lib) optionals;
 
   basePackages = [
-    pkgs.elixir_1_15
+    pkgs.elixir
     pkgs.elixir_ls
     pkgs.git
     pkgs.nixfmt


### PR DESCRIPTION
## Changed

- Downgraded Elixir from version `1.15.x` to `1.14.x` because the `mix phx.gen.release --docker` command failed searching for a docker image to use
- Updated `Dockerfile` to install `nodejs` and `yarn` to prevent build from failing
- Updated Elixir wrappers for `esbuild` and `tailwind`

## Added

- Fly.io deployment configs generated via `flyctl launch`