### PR TITLE
feat: add custom erorr pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Marketing website [oberan.dev](https://oberan.dev)
 
 ## Development
 
-1. Install Elixir deps with `make deps-ex`
-2. Install Javascript deps with `make deps-js`
-3. Create SSL certs for local developmnt with `make certs`
-4. Run development server with `make run`
+1. Install deps with `make deps`
+2. Create SSL certs for local developmnt with `make certs`
+3. Run development server with `make run`

--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ Marketing website [oberan.dev](https://oberan.dev)
 
 ## Development
 
-1. Install deps with `make deps`
+1. Install project deps with `make deps`
 2. Create SSL certs for local developmnt with `make certs`
 3. Run development server with `make run`

--- a/lib/oberan_web/controllers/error_html.ex
+++ b/lib/oberan_web/controllers/error_html.ex
@@ -8,7 +8,7 @@ defmodule OberanWeb.ErrorHTML do
   #   * lib/oberan_web/controllers/error_html/404.html.heex
   #   * lib/oberan_web/controllers/error_html/500.html.heex
   #
-  # embed_templates "error_html/*"
+  embed_templates "error_html/*"
 
   # The default is to render a plain text page based on
   # the template name. For example, "404.html" becomes

--- a/lib/oberan_web/controllers/error_html/404.html.heex
+++ b/lib/oberan_web/controllers/error_html/404.html.heex
@@ -1,0 +1,1 @@
+<div class="">Custom 404</div>

--- a/lib/oberan_web/controllers/error_html/500.html.heex
+++ b/lib/oberan_web/controllers/error_html/500.html.heex
@@ -1,0 +1,1 @@
+<div class="">Custom 500</div>

--- a/lib/oberan_web/router.ex
+++ b/lib/oberan_web/router.ex
@@ -10,20 +10,11 @@ defmodule OberanWeb.Router do
     plug :put_secure_browser_headers
   end
 
-  # pipeline :api do
-  #   plug :accepts, ["json"]
-  # end
-
   scope "/", OberanWeb do
     pipe_through :browser
 
     get "/", PageController, :home
   end
-
-  # Other scopes may use custom stacks.
-  # scope "/api", OberanWeb do
-  #   pipe_through :api
-  # end
 
   # Enable LiveDashboard and Swoosh mailbox preview in development
   if Application.compile_env(:oberan, :dev_routes) do


### PR DESCRIPTION
*Note:* need to set `debug_errors` to `false` in `config/dev.exs` while developing to see the pages render